### PR TITLE
Remove default state setting in .toc file

### DIFF
--- a/UtilitiesPlus.toc
+++ b/UtilitiesPlus.toc
@@ -3,7 +3,6 @@
 ## Notes: Adds some QOL features
 ## Author: Asaranth
 ## Version: 1.1.0
-## DefaultState: Enabled
 ## Dependencies: Ace3
 ## SavedVariables: UtilitiesPlusDB
 


### PR DESCRIPTION
This change eliminates the unnecessary "DefaultState: Enabled" setting from the .toc file, streamlining the configuration. No functional impact is expected as this is a purely declarative change.