### PR TITLE
Add new commands to clear action bars and quest log.

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -85,6 +85,8 @@ function UtilitiesPlus:PrintHelp()
         {command = "/way clear", description = "Clears the current waypoint."},
         {command = "/way clear all", description = "Clears all waypoints."},
         {command = "/way x y", description = "Sets a waypoint at the specified coordinates or adds it to the queue if another waypoint is active (e.g. /way 45.3 67.8)."},
+        {command = "/clearbars", description = "Clears all spells and items from your action bars."},
+        {command = "/clearquests", description = "Clears all quests in the quest log."}
     }
     self:Print("Available commands:")
     for _, cmd in ipairs(commands) do


### PR DESCRIPTION
This update introduces two new commands: "/clearbars" to clear all spells and items from action bars, and "/clearquests" to clear all quests in the quest log. These additions expand the current set of waypoint and clearing utilities for versatile in-game management.