### PR TITLE
Fix function name capitalization in ClearQuests.lua

### DIFF
--- a/ClearQuests.lua
+++ b/ClearQuests.lua
@@ -32,6 +32,6 @@ function ClearQuests:OnInitialize()
     self:RegisterChatCommand('clearquests', 'ClearQuests')
 end
 
-function clearQuests:ClearQuests()
+function ClearQuests:ClearQuests()
     StaticPopup_Show('CONFIRM_CLEAR_ALL_QUESTS')
 end


### PR DESCRIPTION
Correct function definition by changing 'clearQuests' to 'ClearQuests' to match the intended class name. This ensures proper method invocation and prevents potential runtime errors.